### PR TITLE
Add install_path to command builder

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -105,6 +105,17 @@ When passing in a blob or IOStream, Windows users need to make sure they read th
   #You may run into problems doing it this way
   buffer = StringIO.new(File.read(IMAGE_PATH))
 
+== Windows Users (2) by Pika
+
+I got "no such file" error when using ANY method of mini-magick
+
+I spent a day to trace down, turns out the Process.spawn cannot find "gm" (even though the *magick paths are added to PATH)
+
+So you can now specify the install path if you have this problem by adding this to config/application.rb
+
+  MiniMagick::CommandBuilder.install_path = "C:/GraphicsMagick-1.3.13-Q16"
+
+Please use "/" instead of "\" to avoid any problem, also the "/" at the end of string is optional
 
 == Using GraphicsMagick
 

--- a/lib/mini_magick.rb
+++ b/lib/mini_magick.rb
@@ -444,7 +444,7 @@ module MiniMagick
     attr :command
     
     # Path of ImageMagick or GMagick
-    @install_path = nil
+    @@install_path = nil
     class << self
       attr_accessor :install_path
     end

--- a/lib/mini_magick.rb
+++ b/lib/mini_magick.rb
@@ -443,8 +443,9 @@ module MiniMagick
     attr :args
     attr :command
     
+    # Path of ImageMagick or GMagick
+    @install_path = nil
     class << self
-      # Path of ImageMagick or GMagick, 
       attr_accessor :install_path
     end
 

--- a/lib/mini_magick.rb
+++ b/lib/mini_magick.rb
@@ -444,7 +444,6 @@ module MiniMagick
     attr :command
     
     # Path of ImageMagick or GMagick
-    @@install_path = nil
     class << self
       attr_accessor :install_path
     end
@@ -457,9 +456,9 @@ module MiniMagick
 
     def command
       result = ""
-      if !@@install_path.nil?
-        result << @@install_path
-        result << "/" unless @@install_path =~ /\/$/
+      if !MiniMagick::CommandBuilder.install_path.nil?
+        result << MiniMagick::CommandBuilder.install_path
+        result << "/" unless MiniMagick::CommandBuilder.install_path =~ /\/$/
       end
       result << "#{MiniMagick.processor} #{@command} #{@args.join(' ')}".strip
       result

--- a/lib/mini_magick.rb
+++ b/lib/mini_magick.rb
@@ -442,6 +442,11 @@ module MiniMagick
   class CommandBuilder
     attr :args
     attr :command
+    
+    class << self
+      # Path of ImageMagick or GMagick, 
+      attr_accessor :install_path
+    end
 
     def initialize(command, *options)
       @command = command
@@ -450,7 +455,13 @@ module MiniMagick
     end
 
     def command
-      "#{MiniMagick.processor} #{@command} #{@args.join(' ')}".strip
+      result = ""
+      if !@@install_path.nil?
+        result << @@install_path
+        result << "/" unless @@install_path =~ /\/$/
+      end
+      result << "#{MiniMagick.processor} #{@command} #{@args.join(' ')}".strip
+      result
     end
 
     def method_missing(symbol, *options)


### PR DESCRIPTION
Well I have problem when using mini-magick
Turns out the Process.spawn cannot find "gm" (if use GMagick) in PATH
so have to add manually =3=
